### PR TITLE
added use auth token according to new hugging face

### DIFF
--- a/parrot/parrot.py
+++ b/parrot/parrot.py
@@ -1,14 +1,17 @@
+from typing import Text
+
+
 class Parrot():
   
-  def __init__(self, model_tag="prithivida/parrot_paraphraser_on_T5", use_gpu=False):
+  def __init__(self, use_auth_token: Text, model_tag="prithivida/parrot_paraphraser_on_T5", use_gpu=False):
     from transformers import AutoTokenizer
     from transformers import AutoModelForSeq2SeqLM
     import pandas as pd
     from parrot.filters import Adequacy
     from parrot.filters import Fluency
     from parrot.filters import Diversity
-    self.tokenizer = AutoTokenizer.from_pretrained(model_tag)
-    self.model     = AutoModelForSeq2SeqLM.from_pretrained(model_tag)
+    self.tokenizer = AutoTokenizer.from_pretrained(model_tag, use_auth_token = use_auth_token)
+    self.model     = AutoModelForSeq2SeqLM.from_pretrained(model_tag, use_auth_token = use_auth_token)
     self.adequacy_score = Adequacy()
     self.fluency_score  = Fluency()
     self.diversity_score= Diversity()


### PR DESCRIPTION
Since hugging face has updated their API, you cannot access Parrot models without using an auth token.
You may land into this issue

...is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'....

To solve this I added a new parameter called ```use_auth_token```. 

**How to get a token from Huggingface**
1) Open [Hugging Face](https://huggingface.co/login) and register/login with your credentials
2) Nativate to [Token settings](https://huggingface.co/settings/tokens) page and create a ```write``` permitted access token. 
3) Copy the token and pass it as a parameter to ```Parrot``` class while initiating.


So the updated code will be

```
from parrot import Parrot
import torch
import warnings
warnings.filterwarnings("ignore")

''' 
uncomment to get reproducable paraphrase generations
def random_state(seed):
  torch.manual_seed(seed)
  if torch.cuda.is_available():
    torch.cuda.manual_seed_all(seed)

random_state(1234)
'''

#Init models (make sure you init ONLY once if you integrate this to your code)
parrot = Parrot(model_tag="prithivida/parrot_paraphraser_on_T5", use_auth_token = "<Your Hugging Face token>")

phrases = ["Can you recommend some upscale restaurants in Newyork?",
           "What are the famous places we should not miss in Russia?"
]

for phrase in phrases:
  print("-"*100)
  print("Input_phrase: ", phrase)
  print("-"*100)
  para_phrases = parrot.augment(input_phrase=phrase, use_gpu=False)
  for para_phrase in para_phrases:
   print(para_phrase)
```