### PR TITLE
fix: add missing dependencies into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-transformers 
+transformers[torchhub]
 sentencepiece
 python-Levenshtein 
 fuzzywuzzy
 sentence-transformers
-
+pandas


### PR DESCRIPTION
- `pandas` is imported in a few places in the code
- `transformers` needs to be installed with `torchhub` extras othewise it ends up with following error:

```
Traceback (most recent call last):
  File "/Users/yed/dev/foo/bar/phraser/phrase.py", line 114, in <module>
    parrot = Parrot(model_tag="prithivida/parrot_paraphraser_on_T5")
  File "/Users/yed/dev/foo/bar/phraser/Parrot_Paraphraser/parrot/parrot.py", line 10, in __init__
    self.tokenizer = AutoTokenizer.from_pretrained(model_tag, use_auth_token=True)
  File "/Users/yed/.pyenv/versions/godot39/lib/python3.9/site-packages/transformers/models/auto/tokenization_auto.py", line 628, in from_pretrained
    return tokenizer_class_fast.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
  File "/Users/yed/.pyenv/versions/godot39/lib/python3.9/site-packages/transformers/tokenization_utils_base.py", line 1775, in from_pretrained
    return cls._from_pretrained(
  File "/Users/yed/.pyenv/versions/godot39/lib/python3.9/site-packages/transformers/tokenization_utils_base.py", line 1930, in _from_pretrained
    tokenizer = cls(*init_inputs, **init_kwargs)
  File "/Users/yed/.pyenv/versions/godot39/lib/python3.9/site-packages/transformers/models/t5/tokenization_t5_fast.py", line 134, in __init__
    super().__init__(
  File "/Users/yed/.pyenv/versions/godot39/lib/python3.9/site-packages/transformers/tokenization_utils_fast.py", line 114, in __init__
    fast_tokenizer = convert_slow_tokenizer(slow_tokenizer)
  File "/Users/yed/.pyenv/versions/godot39/lib/python3.9/site-packages/transformers/convert_slow_tokenizer.py", line 1162, in convert_slow_tokenizer
    return converter_class(transformer_tokenizer).converted()
  File "/Users/yed/.pyenv/versions/godot39/lib/python3.9/site-packages/transformers/convert_slow_tokenizer.py", line 434, in __init__
    requires_backends(self, "protobuf")
  File "/Users/yed/.pyenv/versions/godot39/lib/python3.9/site-packages/transformers/utils/import_utils.py", line 967, in requires_backends
    raise ImportError("".join(failed))
ImportError:
T5Converter requires the protobuf library but it was not found in your environment. Checkout the instructions on the
installation page of its repo: https://github.com/protocolbuffers/protobuf/tree/master/python#installation and follow the ones
that match your environment.
```